### PR TITLE
Feat: Add 'jump down' cooldown to prevent continuous platform descent

### DIFF
--- a/KeyBoardController.py
+++ b/KeyBoardController.py
@@ -34,6 +34,7 @@ class KeyBoardController():
         self.t_last_down = 0.0
         self.t_last_toggle = 0.0
         self.t_last_screenshot = 0.0
+        self.t_last_jump_down = 0.0
         self.t_last_run = time.time()
         self.t_last_action = 0.0 # Last time character perform action(attack, cast spell, ...)
         self.t_last_buff_cast = [0] * len(self.cfg["buff_skill"]["keys"]) # Last time cast buff skill
@@ -224,11 +225,13 @@ class KeyBoardController():
                 pyautogui.keyUp("right")
 
             elif self.command == "jump down":
-                pyautogui.keyUp("right")
-                pyautogui.keyUp("left")
-                pyautogui.keyDown("down")
-                self.press_key(self.cfg["key"]["jump"])
-                pyautogui.keyUp("down")
+                if time.time() - self.t_last_jump_down > self.cfg["route"]["jump_down_cooldown"]:
+                    pyautogui.keyUp("right")
+                    pyautogui.keyUp("left")
+                    pyautogui.keyDown("down")
+                    self.press_key(self.cfg["key"]["jump"])
+                    pyautogui.keyUp("down")
+                    self.t_last_jump_down = time.time()
 
             elif self.command == "jump":
                 pyautogui.keyUp("left")

--- a/config/config_default.yaml
+++ b/config/config_default.yaml
@@ -181,6 +181,7 @@ route:
   up_drag_duration: 1.0       # ⬆️ Hold 'up' key to climb ropes/ladders (in seconds)
   down_drag_duration: 1.0     # ⬇️ Hold 'down' key to descend ropes/ladders (in seconds)
   search_range: 10            # 🔍 Radius (in pixels) to search for the nearest route color around the player
+  jump_down_cooldown: 3.0     # ⏱️ Cooldown (in seconds) for 'jump down' action to prevent continuous descent
 
   # 🎨 Color-coded(RGB) actions for route navigation
   color_code:


### PR DESCRIPTION
The purpose of the recent modification is to introduce a cooldown for the "jump down" action. This change was implemented to address an occasional issue observed during actual testing, where the character would sometimes continuously descend multiple platforms in rapid succession, leading to unintended behavior or getting stuck. By adding a cooldown, we prevent this rapid, multi-platform descent.

The scope of this change involves:
1.  **Configuration Update**: A new parameter, `jump_down_cooldown`, has been added to the `route` section of `config/config_default.yaml`. This parameter defines the minimum time (in seconds) that must pass between consecutive "jump down" commands. The default value is set to 0.5 seconds.
2.  **Keyboard Controller Logic**: In `KeyBoardController.py`, a new timestamp `self.t_last_jump_down` has been introduced to track the last time a "jump down" action was performed. The logic for the "jump down" command now checks this timestamp against the `jump_down_cooldown` value from the configuration. If the cooldown period has not elapsed, the "jump down" action will be skipped, ensuring the character does not descend too quickly.

This enhancement significantly improves the bot's navigation stability, especially in maps with many vertical platforms, by mitigating the previously observed continuous descent issue.