### PR TITLE
Auto return when no potion

### DIFF
--- a/KeyBoardController.py
+++ b/KeyBoardController.py
@@ -43,6 +43,7 @@ class KeyBoardController():
         self.is_need_screen_shot = False
         self.is_need_toggle = False
         self.is_need_force_heal = False
+        self.is_need_return = False
         # Parameters
         self.debounce_interval = self.cfg["system"]["key_debounce_interval"]
         self.fps_limit = self.cfg["system"]["fps_limit_keyboard_controller"]
@@ -210,6 +211,10 @@ class KeyBoardController():
                 not self.command in ["up", "down", "jump right", "jump left"]:
                 self.command = "add hp"
 
+            # Check if is needed to return
+            if self.is_need_return:
+                self.command = "return_home"
+
             if self.command == "walk left":
                 pyautogui.keyUp("right")
                 pyautogui.keyDown("left")
@@ -304,6 +309,12 @@ class KeyBoardController():
 
             elif self.command == "add mp":
                 self.press_key(self.cfg["key"]["add_mp"])
+                self.command = ""
+                
+            elif self.command == "return_home":
+                self.press_key(self.cfg["is_use_return_if_no_potion"]["return_home_key"])
+                self.release_all_key()
+                self.disable()
                 self.command = ""
 
             else:

--- a/config/config_default.yaml
+++ b/config/config_default.yaml
@@ -198,6 +198,14 @@ auto_change_channel: ""
 other_player_move_pixel: 10  # only work when auto_change_channel == "pixel" 
 
 # ────────────────
+# Return_if_no_potion
+# ────────────────
+is_use_return_if_no_potion:
+  enable: False
+  return_home_key: "Home"       # 🔁 Key to use return home scroll.
+  return_watch_dog_timeout: 3   # 🕒 Duration to detect HP is lower than "add_hp_ratio"
+
+# ────────────────
 # 🧭 Route Following
 # ────────────────
 # The character follows a pre-defined route image (route*.png) using color-coded commands.


### PR DESCRIPTION
This function uses the HP ratio setting from the HealthMonitor. If the HP stays below add_hp_ratio for longer than the specified duration, it define as no potion left and triggers the return scroll key and disables the keyboard to make the character stay in place.

Hi Kenyu,
Sorry I’m currently on a business trip and unable to test it myself.
If you could quickly confirm there’s no error before merging, I’d really appreciate it!

