### PR TITLE
[Fix]  #106 workaround for Mac win32gui not defined

### DIFF
--- a/mapleStoryAutoLevelUp.py
+++ b/mapleStoryAutoLevelUp.py
@@ -1871,7 +1871,7 @@ class MapleStoryBot:
             self.kb.is_need_screen_shot = False
 
         # Make sure player is in party
-        if self.is_first_frame is True:
+        if self.is_first_frame is True and is_mac():
             activate_game_window(self.cfg["game_window"]["title"])
             time.sleep(0.3)
             self.ensure_is_in_party()


### PR DESCRIPTION
Workaround for Mac win32gui not defined.
Let me know if the Mac version of **activate_game_window** is needed