### PR TITLE
Fix syntax errors in f-strings

### DIFF
--- a/src/input/GameWindowCapturorForMac.py
+++ b/src/input/GameWindowCapturorForMac.py
@@ -62,7 +62,9 @@ class GameWindowCapturor:
 
         self.window_title = get_window_title(cfg["game_window"]["title"])
         if self.window_title is None:
-            logger.error(f"[GameWindowCapturor] Unable to find window titles that contain {cfg["game_window"]["title"]}")
+            logger.error(
+                f"[GameWindowCapturor] Unable to find window titles that contain {cfg['game_window']['title']}"
+            )
             return -1
 
         self.fps = 0

--- a/src/legacy/mapleStoryAutoLevelUp_legacy.py
+++ b/src/legacy/mapleStoryAutoLevelUp_legacy.py
@@ -248,7 +248,8 @@ class MapleStoryBot:
 
             # Print color code on debug image
             cv2.putText(
-                self.img_frame_debug, f"Route Action: {nearest["action"]}",
+                self.img_frame_debug,
+                f"Route Action: {nearest['action']}",
                 (720, 90),
                 cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 255),
                 2, cv2.LINE_AA
@@ -478,7 +479,8 @@ class MapleStoryBot:
 
             # Print color code on debug image
             cv2.putText(
-                self.img_frame_debug, f"Route Action: {nearest["action"]}",
+                self.img_frame_debug,
+                f"Route Action: {nearest['action']}",
                 (720, 90),
                 cv2.FONT_HERSHEY_SIMPLEX, 0.7, (0, 0, 255),
                 2, cv2.LINE_AA
@@ -1045,8 +1047,9 @@ class MapleStoryBot:
         text_list = [
             f"FPS: {self.fps}",
             f"Status: {self.status}",
-            f"Press 'F1' to {"pause" if self.kb.is_enable else "start"} Bot",
-            f"Press 'F2' to save screenshot{" : Saved" if dt_screenshot < 0.7 else ""}"]
+            f"Press 'F1' to {'pause' if self.kb.is_enable else 'start'} Bot",
+            f"Press 'F2' to save screenshot{' : Saved' if dt_screenshot < 0.7 else ''}"
+        ]
         for idx, text in enumerate(text_list):
             cv2.putText(
                 self.img_frame_debug, text,

--- a/tools/AutoDiceRoller.py
+++ b/tools/AutoDiceRoller.py
@@ -93,7 +93,10 @@ class AutoDiceRoller:
 
         # Make sure resolution is as expected
         if self.cfg["game_window"]["size"] != self.frame.shape[:2]:
-            text = f"Unexpeted window size: {self.frame.shape[:2]} (expect {self.cfg["game_window"]["size"]})"
+            text = (
+                f"Unexpeted window size: {self.frame.shape[:2]} "
+                f"(expect {self.cfg['game_window']['size']})"
+            )
             logger.error(text)
             return
 


### PR DESCRIPTION
## Summary
- fix unescaped quotes in f-strings across Mac capture, legacy bot, and dice roller utilities
- ensure `py_compile` passes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_687f47c0b5c48321ac0ea0c5293a6b82