### PR TITLE
Fix minimap border check

### DIFF
--- a/src/utils/common.py
+++ b/src/utils/common.py
@@ -431,8 +431,9 @@ def get_minimap_loc_size(img_frame):
             continue
 
         # Check 1px white left and right margins
-        if not (np.all(img_frame[y0:y0:rh, x0] == white) and \
-                np.all(img_frame[y0:y0:rh, x1] == white)):
+        # Ensures the candidate region is framed by white borders like the minimap
+        if not (np.all(img_frame[y0:y0+rh, x0] == white) and \
+                np.all(img_frame[y0:y0+rh, x1] == white)):
             continue
 
         # Create a mask of non-white pixels


### PR DESCRIPTION
## Summary
- fix vertical border checks in `get_minimap_loc_size`
- clarify intent with a comment

## Testing
- `python3 -m py_compile src/utils/common.py`


------
https://chatgpt.com/codex/tasks/task_e_687f49eee0648321bdbd586c03fbcd35